### PR TITLE
Bottom UX/Navigation fixes

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,5 +1,5 @@
-sdk.dir=/Users/daryleurrea/Library/Android/sdk
-flutter.sdk=/Users/daryleurrea/developer/flutter
+sdk.dir=/Users/thejewell/Library/Android/sdk
+flutter.sdk=/Users/thejewell/Developer/flutter
 flutter.buildMode=debug
 flutter.versionName=1.0.0
 flutter.versionCode=1

--- a/lib/Observables/ScreenNavigator.dart
+++ b/lib/Observables/ScreenNavigator.dart
@@ -1,38 +1,49 @@
 import 'package:mobx/mobx.dart';
 import 'package:untitled3/Utility/Constant.dart';
+
 part 'ScreenNavigator.g.dart';
+
 class MainNavObserver = _AbstractMainNavObserver with _$MainNavObserver;
 
 abstract class _AbstractMainNavObserver with Store {
-
   @observable
   dynamic currentScreen;
 
   @observable
-  String screenTitle ="";
+  String screenTitle = "";
 
   @observable
   dynamic focusedNavBtn = 0;
 
   @action
-  void changeScreen(dynamic screen){
+  void changeScreen(dynamic screen) {
     print("Screen changed to: $screen");
     currentScreen = screen;
     focusedNavBtn = -1;
+    // if (screen == MAIN_SCREENS.MENU) {
+    //   currentScreen = screen;
+    //   focusedNavBtn = 0;
+    // } else if (screen == MAIN_SCREENS.HOME) {
+    //   currentScreen = screen;
+    //   focusedNavBtn = 1;
+    // } else if (screen == MENU_SCREENS.HELP) {
+    //   currentScreen = screen;
+    //   focusedNavBtn = 2;
+    // }
   }
 
   @action
-  void setTitle(String title){
-    print("Change Screen tittle to: "+ title);
+  void setTitle(String title) {
+    print("Change Screen tittle to: " + title);
     screenTitle = title;
-    
   }
 
   @action
-  void setFocusedBtn(dynamic focusedBtn){
+  void setFocusedBtn(dynamic focusedBtn) {
     focusedNavBtn = focusedBtn;
-    if(focusedBtn == 2) currentScreen = MAIN_SCREENS.NOTE;
-    if(focusedBtn == 0) currentScreen = MAIN_SCREENS.MENU;
-  }
 
+    if (focusedBtn == 2) currentScreen = MENU_SCREENS.HELP;
+    if (focusedBtn == 0) currentScreen = MAIN_SCREENS.MENU;
+    if (focusedBtn == 1) currentScreen = MAIN_SCREENS.HOME;
+  }
 }

--- a/lib/Screens/Main.dart
+++ b/lib/Screens/Main.dart
@@ -64,12 +64,14 @@ class _MainNavigatorState extends State<MainNavigator> {
       screenNav.setTitle(I18n.of(context)!.menuScreenName);
       return Menu();
     }
-    if (screen == MAIN_SCREENS.HOME) {
-      screenNav.setTitle(I18n.of(context)!.homeScreenName);
+    if (screen == MAIN_SCREENS.HOME || index == 1) {
+      // screenNav.setTitle(I18n.of(context)!.homeScreenName);
+      screenNav.setTitle("Chat");
       return _speechScreen;
     }
     if (screen == MAIN_SCREENS.CALENDAR) {
       screenNav.setTitle(I18n.of(context)!.calendarScreenName);
+
       return _calendar;
     }
     if (screen == MAIN_SCREENS.CHECKLIST) {
@@ -77,7 +79,8 @@ class _MainNavigatorState extends State<MainNavigator> {
       return _checklist;
     }
     if (screen == MAIN_SCREENS.NOTE) {
-      screenNav.setTitle(I18n.of(context)!.checklistScreenName);
+      // screenNav.setTitle(I18n.of(context)!.checklistScreenName);
+      screenNav.setTitle("Notes");
       return _note;
     }
     if (screen == MAIN_SCREENS.NOTIFICATION) {
@@ -86,7 +89,7 @@ class _MainNavigatorState extends State<MainNavigator> {
     }
 
     //menu screens
-    if (screen == MENU_SCREENS.HELP) {
+    if (screen == MENU_SCREENS.HELP || index == 2) {
       screenNav.setTitle(I18n.of(context)!.menuScreenName);
       return _help;
     }
@@ -99,7 +102,8 @@ class _MainNavigatorState extends State<MainNavigator> {
       return Trigger();
     }
     if (screen == MENU_SCREENS.SETTING) {
-      screenNav.setTitle(I18n.of(context)!.settingScreenName);
+      //screenNav.setTitle(I18n.of(context)!.settingScreenName);
+      screenNav.setTitle("Settings");
       return _settings;
     }
 
@@ -154,6 +158,12 @@ class _MainNavigatorState extends State<MainNavigator> {
     }
   }
 
+  void _onItemTapped(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final micObserver = Provider.of<MicObserver>(context);
@@ -166,7 +176,7 @@ class _MainNavigatorState extends State<MainNavigator> {
       builder: (_) => Scaffold(
         resizeToAvoidBottomInset: false,
         appBar: AppBar(
-          titleTextStyle: TextStyle(color: Colors.blue[700]),
+          titleTextStyle: TextStyle(color: Colors.black),
           toolbarHeight: 50,
           centerTitle: true,
           title: Column(
@@ -211,8 +221,14 @@ class _MainNavigatorState extends State<MainNavigator> {
                 onTap: screenNav.setFocusedBtn,
                 selectedItemColor: Colors.black,
                 unselectedItemColor: Colors.black,
-                unselectedLabelStyle: TextStyle(fontSize: 18),
-                selectedLabelStyle: TextStyle(fontSize: 18),
+                unselectedLabelStyle: TextStyle(
+                  fontSize: 18,
+                  color: Colors.black,
+                ),
+                selectedLabelStyle: TextStyle(
+                  fontSize: 18,
+                  color: Colors.black,
+                ),
                 // showUnselectedLabels: true,
                 // showSelectedLabels: true,
                 items: [
@@ -228,6 +244,9 @@ class _MainNavigatorState extends State<MainNavigator> {
                               iconSize: 40,
                               onPressed: () {
                                 screenNav.changeScreen(MAIN_SCREENS.MENU);
+                                screenNav.setFocusedBtn(0);
+                                _currentIndex = 0;
+                                micObserver.micIsExpectedToListen = false;
                               }),
                         ),
                       ),
@@ -245,11 +264,14 @@ class _MainNavigatorState extends State<MainNavigator> {
                             child: IconButton(
                                 icon: new Icon(Icons.mic),
                                 iconSize: 43,
-                                color: (screenNav.focusedNavBtn == 0)
+                                color: (screenNav.focusedNavBtn == 1)
                                     ? Colors.white
                                     : Colors.black,
-                                onPressed: () =>
-                                    {_onClickMic(micObserver, screenNav)}),
+                                onPressed: () => {
+                                      _onClickMic(micObserver, screenNav),
+                                      screenNav.setFocusedBtn(1),
+                                      _currentIndex = 1,
+                                    }),
                           ),
                         ),
                       ),
@@ -268,6 +290,9 @@ class _MainNavigatorState extends State<MainNavigator> {
                               iconSize: 40,
                               onPressed: () {
                                 screenNav.changeScreen(MENU_SCREENS.HELP);
+                                screenNav.setFocusedBtn(2);
+                                _currentIndex = 2;
+                                micObserver.micIsExpectedToListen = false;
                               }),
                         ),
                       ),
@@ -282,4 +307,5 @@ class _MainNavigatorState extends State<MainNavigator> {
     );
   }
 }
+
 //TODO User FittedBox to resize according to the phone's size


### PR DESCRIPTION
Tested android and IOS here: https://trello.com/c/0J2ZNaz8

#1 fixed bottom nav icon to set active icon to white and non active to black
#2 updated titles of pages in menu bar(notes- previously showed checklist, settings- previously showed setting)
3: added functionality that turns off mic pulse animation upon clicking another tab(previously would continue to pulse even if you clicked onto another page unless you clicked the mic again to disable it)