### PR TITLE
Note Date/Time Display Fixes

### DIFF
--- a/lib/Screens/Note/NoteTable.dart
+++ b/lib/Screens/Note/NoteTable.dart
@@ -75,6 +75,7 @@ class _NoteTableState extends State<NoteTable> {
       }
     }
 
+    final RegExp regexp = new RegExp(r'^0+(?=.)');
     bool _checkboxToggle = false;
     void _selectNotes(bool) {
       //todo code here
@@ -194,9 +195,11 @@ class _NoteTableState extends State<NoteTable> {
                           child: Text(
                             widget.usersNotes[index].localText +
                                 '\n(' +
-                                widget.usersNotes[index].eventDate +
-                                ' ' +
-                                widget.usersNotes[index].eventTime +
+                                DateFormat.MMMEd().format(DateTime.parse(
+                                    widget.usersNotes[index].eventDate)) +
+                                ' at ' +
+                                widget.usersNotes[index].eventTime
+                                    .replaceAll(regexp, '') +
                                 ')',
                             style: TEXT_STYLE,
                           )),
@@ -268,9 +271,11 @@ class _NoteTableState extends State<NoteTable> {
                           child: Text(
                             widget.usersNotes[index].localText +
                                 '\n(' +
-                                widget.usersNotes[index].eventDate +
-                                ' ' +
-                                widget.usersNotes[index].eventTime +
+                                DateFormat.MMMEd().format(DateTime.parse(
+                                    widget.usersNotes[index].eventDate)) +
+                                ' at ' +
+                                widget.usersNotes[index].eventTime
+                                    .replaceAll(regexp, '') +
                                 ')',
                             style: TEXT_STYLE,
                           )),

--- a/lib/Screens/Note/SaveNote.dart
+++ b/lib/Screens/Note/SaveNote.dart
@@ -144,6 +144,7 @@ class _SaveNoteState extends State<SaveNote> {
                 " " +
                 noteObserver.currNoteForDetails!.eventTime),
         firstDate: DateTime.now(),
+        use24HourFormat: false,
         lastDate: DateTime(2100),
         icon: Icon(Icons.event),
         //  dateLabelText: dateLabelText,
@@ -176,6 +177,7 @@ class _SaveNoteState extends State<SaveNote> {
       locale: locale,
       dateMask: 'd MMM, yyyy',
       //initialValue: DateTime.now().toString(),
+      use24HourFormat: false,
       firstDate: DateTime.now(),
       lastDate: DateTime(2100),
       icon: Icon(Icons.event),


### PR DESCRIPTION
#1 Adjusted date/time display on notes screen to more readable format
#2 Adjusted Time picker on SaveNote/AddNote screen to 12 hour format