### PR TITLE
Enable Notifications option 

### DIFF
--- a/lib/Model/Setting.dart
+++ b/lib/Model/Setting.dart
@@ -115,8 +115,8 @@ class Setting {
       setting.noteFontSize = fontSizeStringToEnum(jsonObj['noteFontSize']) ?? DEFAULT_FONT_SIZE;
       setting.menuFontSize = fontSizeStringToEnum(jsonObj['menuFontSize']) ?? DEFAULT_FONT_SIZE;
       setting.appTheme = appThemeStringToEnum(jsonObj['appTheme'] ?? DEFAULT_APP_THEME);
-      setting.minutesBeforeNoteNotifications = jsonObj['minutesBeforeNoteNotification'] ?? DEFAULT_MINUTES_BEFORE_NOTE_NOTIFICATIONS;
-      setting.minutesBeforeTaskNotifications = jsonObj['minutesBeforeTaskNotification'] ?? DEFAULT_MINUTES_BEFORE_TASK_NOTIFICATIONS;
+      setting.minutesBeforeNoteNotifications = jsonObj['minutesBeforeNoteNotifications'] ?? DEFAULT_MINUTES_BEFORE_NOTE_NOTIFICATIONS;
+      setting.minutesBeforeTaskNotifications = jsonObj['minutesBeforeTaskNotifications'] ?? DEFAULT_MINUTES_BEFORE_TASK_NOTIFICATIONS;
       setting.enableNotesNotifications = jsonObj['enableNotesNotifications'] ?? DEFAULT_ENABLE_NOTES_NOTIFICATIONS;
       setting.enableTasksNotifications = jsonObj['enableTasksNotifications'] ?? DEFAULT_ENABLE_TASKS_NOTIFICATIONS;
     }

--- a/lib/Screens/Note/SaveNote.dart
+++ b/lib/Screens/Note/SaveNote.dart
@@ -366,15 +366,17 @@ class _SaveNoteState extends State<SaveNote> {
         this._newNote.notification = false;
       }
       if (_reminderNotification == 'Yes') {
-        this._newNote.notification = true;
-        DateTime dateTime =
-            DateTime.parse(_newNote.eventDate + " " + _newNote.eventTime);
-        var _body = _newNote.text +
-            "\n" +
-            _newNote.eventDate +
-            " at " +
-            _newNote.eventTime;
-        notify(_body, dateTime, settingObserver);
+        if (settingObserver.userSettings.enableNotesNotifications) {
+          this._newNote.notification = true;
+          DateTime dateTime =
+          DateTime.parse(_newNote.eventDate + " " + _newNote.eventTime);
+          var _body = _newNote.text +
+              "\n" +
+              _newNote.eventDate +
+              " at " +
+              _newNote.eventTime;
+          notify(_body, dateTime, settingObserver);
+        }
       }
       noteObserver.deleteNote(noteObserver.currNoteForDetails);
       noteObserver.addNote(_newNote);

--- a/lib/Screens/Settings/Setting.dart
+++ b/lib/Screens/Settings/Setting.dart
@@ -16,7 +16,8 @@ import '../../Model/UserModel.dart';
 import '../../Observables/ScreenNavigator.dart';
 
 List<FontSize> fontSizes = [FontSize.SMALL, FontSize.MEDIUM, FontSize.LARGE];
-List<String> _minutesBeforeNotification = ['1', '2', '3', '5', '10', '30'];
+List<String> _minutesBeforeNoteNotification = ['1', '2', '3', '5', '10', '30'];
+List<String> _minutesBeforeTaskNotification = ['1', '2', '3', '5', '10', '30'];
 List<AppTheme> themes = [AppTheme.BLUE, AppTheme.PINK];
 
 List<String> _daysToKeepFilesOptions = ["1", "3", "5", "7", "14", "Forever"];
@@ -191,7 +192,7 @@ class _SettingState extends State<Settings> {
                           .userSettings.minutesBeforeNoteNotifications,
 
                       /// the default or saved value
-                      items: _minutesBeforeNotification
+                      items: _minutesBeforeNoteNotification
                           .map<DropdownMenuItem<String>>((String value) {
                         return DropdownMenuItem<String>(
                           value: value,
@@ -323,7 +324,7 @@ class _SettingState extends State<Settings> {
                       alignment: Alignment.center,
                       value: settingObserver
                           .userSettings.minutesBeforeTaskNotifications,
-                      items: _minutesBeforeNotification
+                      items: _minutesBeforeTaskNotification
                           .map<DropdownMenuItem<String>>((String value) {
                         return DropdownMenuItem<String>(
                           value: value,


### PR DESCRIPTION
Option in Settings should now override individual Note notifications. 

If turned off in Settings, notifications should never appear. 

If turned on, they should be Note-dependent. 